### PR TITLE
Update host.json

### DIFF
--- a/api/host.json
+++ b/api/host.json
@@ -10,6 +10,6 @@
   },
   "extensionBundle": {
     "id": "Microsoft.Azure.Functions.ExtensionBundle",
-    "version": "[1.*, 2.0.0)"
+    "version": "[1.*, 3.0.0)"
   }
 }


### PR DESCRIPTION
to fix issue #10 "Referenced bundle Microsoft.Azure.Functions.ExtensionBundle of version 1.8.1 does not meet the required minimum version of 2.6.1. Update your extension bundle reference in host.json to reference 2.6.1 or later"
https://github.com/microsoft/Purview-Custom-Types-Tool-Solution-Accelerator/issues/10
https://github.com/Azure/Azure-Functions/issues/1987